### PR TITLE
remove invalid bottle: unneeded syntax

### DIFF
--- a/Formula/spin.rb
+++ b/Formula/spin.rb
@@ -6,7 +6,6 @@ class Spin < Formula
   version VERSION
   sha256 'ce9413d4982593b4feb50e6cc40ed317450d3c971d3249eeea16c7e8b4b29e61'
 
-  bottle :unneeded
 
   test do
     system "#{bin}/spin", '--version'


### PR DESCRIPTION
I don't know anything about that syntax and how it works. This fix is just a guess based on the error message I got while trying to install `spin`:

```
==> Tapping tmattio/tap
Cloning into '/usr/local/Homebrew/Library/Taps/tmattio/homebrew-tap'...
remote: Enumerating objects: 28, done.
remote: Counting objects: 100% (28/28), done.
remote: Compressing objects: 100% (20/20), done.
remote: Total 28 (delta 5), reused 23 (delta 0), pack-reused 0
Receiving objects: 100% (28/28), done.
Resolving deltas: 100% (5/5), done.
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/tmattio/homebrew-tap/Formula/spin.rb
spin: Calling bottle :unneeded is disabled! There is no replacement.
Please report this issue to the tmattio/tap tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/tmattio/homebrew-tap/Formula/spin.rb:9

Error: Cannot tap tmattio/tap: invalid syntax in tap!
```

Fix #1 